### PR TITLE
Remove extra space from picture element

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -8,7 +8,7 @@ module.exports = {
         "value-no-vendor-prefix": true,
         "property-no-vendor-prefix": true,
         "block-no-empty": true,
-        "selector-no-id": true,
+        "selector-max-id": 0,
         "rule-empty-line-before": ["always-multi-line", {
             "ignore": ["after-comment", "inside-block"]
         }],

--- a/src/03-generic/reset.scss
+++ b/src/03-generic/reset.scss
@@ -85,3 +85,10 @@ textarea,
 select {
   position: relative;
 }
+
+// Remove extra whitespace produced by picture element
+picture {
+  img {
+    vertical-align: top;
+  }
+}


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description

This fix removes the extra space created by the `<picture>` element.

## Risks
- [low] While this actually fixes the layout of existing `<picture>` usages, it does remove some spacing.