### PR TITLE
Change of error color in CSS class .sc-font-error

### DIFF
--- a/src/03-generic/fonts.scss
+++ b/src/03-generic/fonts.scss
@@ -53,7 +53,7 @@
 }
 
 .sc-font-error {
-  color: $color-error-text;
+  color: $color-error;
   margin-top: 4px;
 }
 


### PR DESCRIPTION
First of all, please excuse me if this should not be the right way as how to bring forward change suggestions for the ShowCar library. I can not claim that I have any deeper knowledge about the library and do not feel comfortable making any (big) changes. It's just something I stumbled upon. If I should better bring forward such change requests in the Slack channel or somewhere else instead of making a PR, please let me know.

/cc @AutoScout24/web-experience

## Description
As due to a comment in src/01-settings/variables.css, "$color-error should be used instead of $color-error-text". So if this is the error color to go with, I only thought it consequent to also change the ".sc-font-error" class in src/03-generic/fonts.css to $color-error from $color-error-text.

