### PR TITLE
Add decimal modifier for sc-list

### DIFF
--- a/src/06-components/atoms/list/docs/list-decimal.html
+++ b/src/06-components/atoms/list/docs/list-decimal.html
@@ -1,5 +1,5 @@
-<ul class="sc-list sc-list--disc">
+<ol class="sc-list sc-list--decimal">
     <li>One</li>
     <li>Two</li>
     <li>Three</li>
-</ul>
+</ol>

--- a/src/06-components/atoms/list/docs/list-decimal.md
+++ b/src/06-components/atoms/list/docs/list-decimal.md
@@ -1,0 +1,1 @@
+<h2>List decimal<span class="status approved">Approved</span></h2>

--- a/src/06-components/atoms/list/list.scss
+++ b/src/06-components/atoms/list/list.scss
@@ -9,3 +9,7 @@
 .sc-list--disc {
   list-style-type: disc;
 }
+
+.sc-list--decimal {
+  list-style-type: decimal;
+}


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description

Adding support for numbered lists with `list-style-type: decimal`

## Risks
- [NONE] This is a new feature