### PR TITLE
Remove 'return false' as this stops event propagation - e.preventDefa…

### DIFF
--- a/src/07-utilities/scroll.js
+++ b/src/07-utilities/scroll.js
@@ -48,6 +48,5 @@ export default function registerSmoothScrolling() {
     $(document).on('click', '.sc-smooth-scroll, [data-smooth-scroll]', (e) => {
         e.preventDefault();
         smoothScroll(e.currentTarget);
-        return false;
     });
 }


### PR DESCRIPTION
…ult() should be sufficient

/cc @AutoScout24/web-experience

## Description

Remove 'return false' as this stops event propagation - e.preventDefault() should be sufficient.

## Risks
- [HIGH|medium|low] Describe possible risk here
