### PR TITLE
Fix name for identity cookie name

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -44,7 +44,7 @@ const whiteList = [
     '__RequestVerificationToken',
     'test-cookie',
     '__ut',
-    'as24identity',
+    'as24_identity',
     'noauth'
 ];
 


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description

There is a typo in the name of the cookie to be whitelisted (missing underscore).

## Risks
- [HIGH|medium|low] Describe possible risk here
