### PR TITLE
list-with-links: Move html code from md file to example html ^maximilian-lindsey

### DIFF
--- a/src/06-components/molecules/list-with-links/docs/list-with-links.html
+++ b/src/06-components/molecules/list-with-links/docs/list-with-links.html
@@ -3,3 +3,23 @@
     <li><a href="https://www.autoscout24.de/auto/bmw/"><span>BMW</span></a></li>
     <li><a href="https://www.autoscout24.de/auto/ford/"><span>Ford</span></a></li>
 </ul>
+
+<br><hr><br>
+<h1>Example with<code>sc-grid-col-*</code></h1>
+<br><br>
+
+<div class="sc-grid-row">
+    <ul class="sc-link-list sc-grid-col-4 sc-grid-col-s-6">
+        <li><a href="https://www.autoscout24.de/auto/audi/"><span>Audi</span></a></li>
+        <li><a href="https://www.autoscout24.de/auto/bmw/"><span>BMW</span></a></li>
+    </ul>
+    <ul class="sc-link-list sc-grid-col-4 sc-grid-col-s-6">
+        <li><a href="https://www.autoscout24.de/auto/porsche/"><span>Porsche</span></a></li>
+    </ul>
+    <ul class="sc-link-list sc-grid-col-4 sc-grid-col-s-6 sc-hidden-s">
+        <li><a href="https://www.autoscout24.de/auto/renault/"><span>Renault</span></a></li>
+        <li><a href="https://www.autoscout24.de/auto/skoda/"><span>Skoda</span></a></li>
+        <li><a href="https://www.autoscout24.de/auto/tesla/"><span>Tesla</span></a></li>
+    </ul>
+</div>
+

--- a/src/06-components/molecules/list-with-links/docs/list-with-links.md
+++ b/src/06-components/molecules/list-with-links/docs/list-with-links.md
@@ -4,19 +4,3 @@ Showcar-ui library delivers styles for links display and arrow on the left. All 
 
 Responsive columns width could be achieved with flexbox or with `sc-grid-col-*` styling.
 
-```html
-<div class="sc-grid-row">
-    <ul class="sc-link-list sc-grid-col-4 sc-grid-col-s-6">
-        <li><a href="https://www.autoscout24.de/auto/audi/"><span>Audi</span></a></li>
-        <li><a href="https://www.autoscout24.de/auto/bmw/"><span>BMW</span></a></li>
-    </ul>
-    <ul class="sc-link-list sc-grid-col-4 sc-grid-col-s-6">
-        <li><a href="https://www.autoscout24.de/auto/porsche/"><span>Porsche</span></a></li>
-    </ul>
-    <ul class="sc-link-list sc-grid-col-4 sc-grid-col-s-6 sc-hidden-s">
-        <li><a href="https://www.autoscout24.de/auto/renault/"><span>Renault</span></a></li>
-        <li><a href="https://www.autoscout24.de/auto/skoda/"><span>Skoda</span></a></li>
-        <li><a href="https://www.autoscout24.de/auto/tesla/"><span>Tesla</span></a></li>
-    </ul>
-</div>
-```


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
list-with-links: We moved the html code from the markdown file to the example html file, so that we have the `.sc-grid-col-*` as showing example as well. 


## Risks
- [low] Describe possible risk here
