### PR TITLE
fixing order of the reversed media section in S and M views

### DIFF
--- a/src/06-components/molecules/media-section/media-section.scss
+++ b/src/06-components/molecules/media-section/media-section.scss
@@ -12,11 +12,13 @@
 
 .sc-media-section--reverse {
   .sc-media-section__content {
+    order: 2;
     @include mqmin($viewportL) {
       order: 1;
     }
   }
   .sc-media-section__pic {
+    order: 1;
     @include mqmin($viewportL) {
       order: 2;
       margin-left: $XXXL;


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
added missing order of the content and media in the media-section


## Risks
- [HIGH|medium|low] Describe possible risk here
No risks
