### PR TITLE
Add consentForAds cookie

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -62,7 +62,8 @@ const whiteList = [
     'brand-pageview-counter',
     'page-views-feed',
     'last-search-feed',
-    'home-feed-bucket'
+    'home-feed-bucket',
+    'consentForAds'
 ];
 
 const deleteCookieByName = function(cookie) {


### PR DESCRIPTION
This pull request whitelists the `consentForAds` cookie. This cookie is set once consent is given using the new Faktor.io consent management platform, once this cookie is set personalised ads can be displayed.