### PR TITLE
SNL-711 - Whitelists as24AutoAboMobileAppView cookie

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -6,6 +6,7 @@ const whiteList = [
     '_gat',
     'AMP_TOKEN',
     'as24AutoAboLike2Drive',
+    'as24AutoAboMobileAppView',
     'as24-gtmSearchCrit',
     'as24Visitor',
     'culture',


### PR DESCRIPTION
Co-authored-by: Ben <b.tarenne@thoughtworks.com>

/cc @AutoScout24/web-experience

## Description
Whitelists the as24AutoAboMobileAppView cookie used in Auto-Abo by Team Extendor in order to hide the header when the traffic may come from native apps.
