### PR TITLE
Cmp 244 show tsm cookie

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -37,7 +37,6 @@ const whiteList = [
     'optimizelyRedirectData',
     'optimizelyReferrer',
     'showTsm',
-    'urugot-bucket',
     'PLAY_SESSION',
     'gaid',
     'asvid',

--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -36,7 +36,6 @@ const whiteList = [
     '_gat_ALL',
     'optimizelyRedirectData',
     'optimizelyReferrer',
-    'showTsm',
     'PLAY_SESSION',
     'gaid',
     'asvid',

--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -37,6 +37,7 @@ const whiteList = [
     'optimizelyRedirectData',
     'optimizelyReferrer',
     'showTsm',
+    'urugot-bucket',
     'PLAY_SESSION',
     'gaid',
     'asvid',


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
- removed obsolte showTsm cookie from whitelist
https://jira.autoscout24.com/browse/CMP-244

## Risks
- low
