### PR TITLE
Removed testmode cookie from whitelist

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -9,7 +9,6 @@ const whiteList = [
     'as24AutoAboMobileAppView',
     'as24Visitor',
     'culture',
-    'testmode',
     'toguru',
     'User',
     'cmpatt',


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
- removed obsolete cookie 'testmode'


## Risks
- low
