### PR TITLE
Whitelist cookie for login wall redirect url

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -53,7 +53,8 @@ const whiteList = [
     'sso',
     'group',
     '.+\\.as24ident',
-    'disable-cmp'
+    'disable-cmp',
+    'loginWallFwdUrl'
 ];
 
 const deleteCookieByName = function(cookie) {


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
- if user register via the new login wall we'd like to send him back to the page where he was coming from
- to be able to do it we'll save the current url from user within this cookie
- we'll delete the cookie right after redirecting the user


## Risks
- low
