### PR TITLE
SEC-10446 use env variables for untrusted input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,11 +90,15 @@ jobs:
           find deploy -type f -iname "*.sh" -exec chmod 755 {} \;
         working-directory: ${{env.RELEASE_BRANCH}}
       - name: Commit and push
+        env:
+          USER_NAME: ${{ github.event.pusher.name }}
+          EMAIL: ${{ github.event.pusher.email }}
+          MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          git config user.name ${{ github.event.pusher.name }}
-          git config user.email ${{ github.event.pusher.email }}
+          git config user.name "$USER_NAME"
+          git config user.email "$EMAIL"
           git add . -A
-          git commit -m "${{ github.event.head_commit.message }}"
+          git commit -m "'$MESSAGE'"
           git push
         working-directory: ${{env.RELEASE_BRANCH}}
 
@@ -131,10 +135,14 @@ jobs:
           cp -r ../artifacts/dist .
         working-directory: ${{env.DOCS_BRANCH}}
       - name: Commit and push
+        env:
+          USER_NAME: ${{ github.event.pusher.name }}
+          EMAIL: ${{ github.event.pusher.email }}
+          MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          git config user.name ${{ github.event.pusher.name }}
-          git config user.email ${{ github.event.pusher.email }}
+          git config user.name "$USER_NAME"
+          git config user.email "$EMAIL"
           git add . -A
-          git commit -m "${{ github.event.head_commit.message }}"
+          git commit -m "'$MESSAGE'"
           git push
         working-directory: ${{env.DOCS_BRANCH}}


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
Resolving security ticket [SEC-10446](https://jira.autoscout24.com/browse/SEC-10446) by setting untrusted input value to an intermediate environment variable. See explanation of fix [here in 'Remediation' section](https://securitylab.github.com/research/github-actions-untrusted-input/).


## Risks
- Risk of script injection if we do not fix.
