### PR TITLE
SEE-1774: Whitelist as24-cmp cookies

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -62,7 +62,9 @@ const whiteList = [
     'combined-leads',
     'rmStoreGateway',
     'IDP',
-    'abtest210'
+    'abtest210',
+    'as24-cmp-signature',
+    'show-as24-cmp'
 ];
 
 const deleteCookieByName = function(cookie) {


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
- https://jira.autoscout24.com/browse/SEE-1774
- Whitelist cookies for as24-cmp
- as24-cmp-signature is to store the digital signature of user consents
- show-as24-cmp is to show as24-cmp cookie banner across AS24 websites


## Risks
- [low] 
